### PR TITLE
add "disabled" attribute to Queue and Group

### DIFF
--- a/rt-client-rest/lib/RT/Client/REST/Group.pm
+++ b/rt-client-rest/lib/RT/Client/REST/Group.pm
@@ -66,7 +66,12 @@ sub _attributes {{
             type   => ARRAYREF,
         },
         list       => 1,
-    }
+    },
+    disabled => {
+        validation => {
+            type   => SCALAR,
+        },
+    },
 }}
 
 =head1 ATTRIBUTES

--- a/rt-client-rest/lib/RT/Client/REST/Queue.pm
+++ b/rt-client-rest/lib/RT/Client/REST/Queue.pm
@@ -99,6 +99,12 @@ sub _attributes {{
         },
         rest_name => 'DefaultDueIn',
     },
+
+    disabled => {
+        validation => {
+            type   => SCALAR,
+        },
+    },
 }}
 
 =head1 ATTRIBUTES


### PR DESCRIPTION
These attributes were added in 4.2.2. Since the code doesn't know about them, "Unknown key: disabled" warnings are issued on object retrieval.

Cheers
-Tom
