### PR TITLE
Fix example in documentation for search()

### DIFF
--- a/rt-client-rest/lib/RT/Client/REST.pm
+++ b/rt-client-rest/lib/RT/Client/REST.pm
@@ -1011,8 +1011,8 @@ using C<show()> method:
     query => "Status = 'stalled'",
   );
   for my $id (@ids) {
-    my ($ticket) = $rt->show(type => 'ticket', ids => [$id]);
-    print "Subject: ", $t->{Subject}, "\n";
+    my ($ticket) = $rt->show(type => 'ticket', id => $id);
+    print "Subject: ", $ticket->{Subject}, "\n";
   }
 
 =item comment (ticket_id => $id, message => $message, %opts)


### PR DESCRIPTION
This is the fix for the ticket https://rt.cpan.org/Ticket/Display.html?id=98160 . 

The requestor also mentioned that `$ticket->{_subject}` worked, but I think
that was because they were using `RT::Client::REST::Ticket` rather than
`RT::Client::REST`. `$ticket->{Subject}` works alright for the latter.