### PR TITLE
Add a method to retrieve attachments metadata.

### DIFF
--- a/rt-client-rest/lib/RT/Client/REST.pm
+++ b/rt-client-rest/lib/RT/Client/REST.pm
@@ -1062,6 +1062,18 @@ B<bcc>, and B<attachments> parameters (see C<comment> above).
 
 Get a list of numeric attachment IDs associated with ticket C<$id>.
 
+=item get_attachments_metadata (id => $id)
+
+Get a list of the metadata related to every attachment of the ticket <$id>
+Every member of the list is a hashref with the shape:
+
+  {
+    id       => $attachment_id,
+    Filename => $attachment_filename,
+    Type     => $attachment_type,
+    Size     => $attachment_size,
+  }
+
 =item get_attachment (parent_id => $parent_id, id => $id, undecoded => $bool)
 
 Returns reference to a hash with key-value pair describing attachment


### PR DESCRIPTION
Typically, to retrieve a given ticket's attachments, one would:
1. Retrieve attachments ids via 'get_attachment_ids', specifying the
ticket id.
2. Retrieve every attachment passing its id to 'get_attachment'.

The problem is: due to the fact that RT seems to model the contents of a
given ticket transactions as attachments of the ticket, this would lead
to an undesired and unexpected effect for the end user:
A request to RT would be issued to attempt to retrieve an attachment
(get_attachment) for _every transaction the ticket has_.
So, for example, given a ticket with 1 attachment and 358 transactions,
one would end up performing 358 requests to RT in order to retrieve that
single attachment.

To solve this, a possible approach would have been to alter the behavior
of 'get_attachment_ids' to discard attachments if they are transactions
content. But, this would break RT::Client::REST's outer API backwards
compatibility.

Another way to tackle this would have been to make the user of
RT::Client::REST responsible of filtering attachments returned by
'get_attachment_ids'. The problem is that since it returns only ids,
this approach is not possible: the user would have to make a request to
retrieve the attachment in order to be provided with the information
needed to filter it out (or not).

So, in order to solve the described problem and, at the same time, avoid
causing too much breakage, a method was added to RT::Client::REST:
'get_attachments_metadata'.
Given a ticket, this method will return the following information for
every one of its attachments: id, filename, type and size.
{id => $id, Filename => $filename, Type => $type, Size => $size}
