### PR TITLE
Fix tests that were failing on Windows

### DIFF
--- a/t/80-timeout.t
+++ b/t/80-timeout.t
@@ -37,7 +37,7 @@ if (0 == $pid) {                                            # Child
 plan tests => 8;                                            # Parent
 for my $timeout (1, 2, 5, 10) {
     my $rt = RT::Client::REST->new(
-        server => "http://localhost:$port",
+        server => "http://127.0.0.1:$port",
         timeout => $timeout,
     );
     my $t1 = time;

--- a/t/81-submit.t
+++ b/t/81-submit.t
@@ -37,7 +37,7 @@ response text");
 
 plan tests => 1;
 my $rt = RT::Client::REST->new(
-        server => "http://localhost:$port",
+        server => "http://127.0.0.1:$port",
         timeout => 2,
 );
 my $res = $rt->_submit("ticket/1", undef, {

--- a/t/82-stringify.t
+++ b/t/82-stringify.t
@@ -30,7 +30,7 @@ die "cannot fork: $!" unless defined $pid;
 
 if (0 == $pid) {                                            # Child
     my $rt = RT::Client::REST->new(
-            server => "http://localhost:$port",
+            server => "http://127.0.0.1:$port",
             # This ensures that we die soon.  When the client dies, the
             # while (<$client>) above stops looping.
             timeout => 2,

--- a/t/83-attachments.t
+++ b/t/83-attachments.t
@@ -110,7 +110,7 @@ plan tests => 4;
 }
 
 my $rt = RT::Client::REST->new(
-    server => "http://localhost:$port",
+    server => "http://127.0.0.1:$port",
     timeout => 2,
 );
 


### PR DESCRIPTION
On some versions of Windows requests to localhost does not work. The
simplest way to fix this is to use 127.0.0.1 instead, which should
always work.

This is part of the CPAN Pull Request Challenge, where I got
RT::Client::REST as my July assignment.