### PR TITLE
Report the current URI on UA errors and handle redirections

### DIFF
--- a/lib/RT/Client/REST.pm
+++ b/lib/RT/Client/REST.pm
@@ -588,7 +588,8 @@ sub _submit {
         # "RT/3.0.1 401 Credentials required"
         if ($status !~ m#^RT/\d+(?:\S+) (\d+) ([\w\s]+)$#) {
             RT::Client::REST::MalformedRTResponseException->throw(
-                'Malformed RT response received from ' . $self->_uri($uri)
+                'Malformed RT response received from ' . $self->_uri($uri) .
+                " with this response: " . substr($text || '', 0, 200) . '....'
             );
         }
 

--- a/lib/RT/Client/REST.pm
+++ b/lib/RT/Client/REST.pm
@@ -700,6 +700,11 @@ sub _ua {
     return $self->{_ua};
 }
 
+sub user_agent {
+    shift->_ua;
+}
+
+
 sub basic_auth_cb {
     my $self = shift;
 
@@ -980,6 +985,10 @@ returns username and password:
 
 A hashref which will be passed to the user agent's constructor for
 maximum flexibility.
+
+=item B<user_agent>
+
+Accessor to the user_agent object.
 
 =item B<logger>
 

--- a/lib/RT/Client/REST.pm
+++ b/lib/RT/Client/REST.pm
@@ -588,7 +588,7 @@ sub _submit {
         # "RT/3.0.1 401 Credentials required"
         if ($status !~ m#^RT/\d+(?:\S+) (\d+) ([\w\s]+)$#) {
             RT::Client::REST::MalformedRTResponseException->throw(
-                'Malformed RT response received from ' . $self->server,
+                'Malformed RT response received from ' . $self->_uri($uri)
             );
         }
 
@@ -662,7 +662,7 @@ sub _submit {
     } else {
         RT::Client::REST::HTTPException->throw(
             code    => $res->code,
-            message => $res->message,
+            message => $res->message . ' fetching ' . $self->_uri($uri),
         );
     }
 
@@ -676,6 +676,7 @@ sub _ua {
         $self->{_ua} = RT::Client::REST::HTTPClient->new(
             agent => $self->_ua_string,
             env_proxy => 1,
+            max_redirect => 1,
         );
         if ($self->timeout) {
             $self->{_ua}->timeout($self->timeout);

--- a/t/86-redirect.t
+++ b/t/86-redirect.t
@@ -1,0 +1,84 @@
+#!perl
+#
+use strict;
+use warnings;
+
+use Test::More;
+use Data::Dumper;
+use Error qw(:try);
+use IO::Socket;
+use RT::Client::REST;
+plan tests => 2;
+
+my $server = IO::Socket::INET->new(
+    Type => SOCK_STREAM,
+    Reuse => 1,
+    Listen => 10,
+) or die "Could not set up TCP server: $@";
+
+my $port = $server->sockport;
+
+my $pid = fork;
+die "cannot fork: $!" unless defined $pid;
+
+if (0 == $pid) {                                    # Child
+    {
+        my $response =
+          "HTTP/1.1 302 Redirect\r\n"                               .
+          "Location: http://127.0.0.1:$port\r\n"                                   .
+          "Content-Type: text/plain; charset=utf-8\r\n\r\n"   .
+          "RT/42foo 200 this is a fake successful response header
+header line 1
+header line 2
+
+response text";
+        my $client = $server->accept;
+        $client->write($response);
+    }
+    {
+        my $response =
+          "HTTP/1.1 302 Redirect\r\n"                               .
+          "Location: http://127.0.0.1:$port\r\n"                                   .
+          "Content-Type: text/plain; charset=utf-8\r\n\r\n"   .
+          "random string";
+        my $client = $server->accept;
+        $client->write($response);
+    }
+    exit;
+}
+
+
+my $rt = RT::Client::REST->new(
+        server => "http://127.0.0.1:$port",
+        timeout => 2,
+);
+eval {
+    my $res = $rt->_submit("ticket/1", undef, {
+                                               user => 'a',
+                                               pass => 'b',
+                                              });
+};
+like $@, qr{fetching .*/REST/1.0/ticket/1}, "Double redirect dies meaningfully";
+
+$pid = fork;
+die "cannot fork: $!" unless defined $pid;
+
+if (0 == $pid) {                                    # Child
+    {
+        my $response =
+          "HTTP/1.1 200 OK\r\n"                               .
+          "Location: http://127.0.0.1:$port\r\n"                                   .
+          "Content-Type: text/plain; charset=utf-8\r\n\r\n"   .
+          "response text";
+        my $client = $server->accept;
+        $client->write($response);
+    }
+    exit;
+}
+eval {
+    my $res = $rt->_submit("ticket/1", undef, {
+                                               user => 'a',
+                                               pass => 'b',
+                                              });
+};
+like $@, qr{Malformed.*/REST/1.0/ticket/1}, "Random data is reported correctly";

--- a/t/86-redirect.t
+++ b/t/86-redirect.t
@@ -8,7 +8,7 @@ use Data::Dumper;
 use Error qw(:try);
 use IO::Socket;
 use RT::Client::REST;
-plan tests => 2;
+plan tests => 5;
 
 my $server = IO::Socket::INET->new(
     Type => SOCK_STREAM,
@@ -49,9 +49,19 @@ response text";
 
 
 my $rt = RT::Client::REST->new(
-        server => "http://127.0.0.1:$port",
-        timeout => 2,
-);
+                               server => "http://127.0.0.1:$port",
+                               timeout => 2,
+                               verbose_errors => 1,
+                               user_agent_args => {
+                                                   agent => 'Secret agent',
+                                                   max_redirect => 0,
+                                                  },
+                              );
+
+is $rt->_ua->agent, 'Secret agent', "Ua correctly initialized";
+is $rt->_ua->max_redirect, 0, "Ua correctly initialized with max redirect";
+ok $rt->verbose_errors, "Verbose errors set";
+
 eval {
     my $res = $rt->_submit("ticket/1", undef, {
                                                user => 'a',

--- a/t/86-redirect.t
+++ b/t/86-redirect.t
@@ -58,8 +58,8 @@ my $rt = RT::Client::REST->new(
                                                   },
                               );
 
-is $rt->_ua->agent, 'Secret agent', "Ua correctly initialized";
-is $rt->_ua->max_redirect, 0, "Ua correctly initialized with max redirect";
+is $rt->user_agent->agent, 'Secret agent', "Ua correctly initialized";
+is $rt->user_agent->max_redirect, 0, "Ua correctly initialized with max redirect";
 ok $rt->verbose_errors, "Verbose errors set";
 
 eval {


### PR DESCRIPTION
This improves greatly the debugging, instead of an opaque message

Also let the module handle the redirections.

There is some code in place which checks the 302, and states that only one
redirect is supported. This makes sense, at it gives us more control about
what's happening.

However, the user agent already handles the redirections, unless instructed
otherwise, making such code unreachable.
