### PR TITLE
Add SLA and SLADisabled attributes

### DIFF
--- a/lib/RT/Client/REST/Queue.pm
+++ b/lib/RT/Client/REST/Queue.pm
@@ -115,6 +115,13 @@ sub _attributes {{
         rest_name => 'CcAddresses',
     },
 
+    sla_disabled => {
+        validation => {
+            type => SCALAR,
+        },
+        rest_name => 'SLADisabled',
+    },
+
 }}
 
 =head1 ATTRIBUTES

--- a/lib/RT/Client/REST/Ticket.pm
+++ b/lib/RT/Client/REST/Ticket.pm
@@ -221,6 +221,13 @@ sub _attributes {{
         rest_name   => 'LastUpdated',
         is_datetime     => 1,
     },
+
+    sla             => {
+        validation  => {
+            type    => SCALAR,
+        },
+    },
+
 }}
 
 =head1 ATTRIBUTES

--- a/t/22-ticket.t
+++ b/t/22-ticket.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 113;
+use Test::More tests => 114;
 use Test::Exception;
 
 use constant METHODS => (
@@ -15,7 +15,7 @@ use constant METHODS => (
     'id', 'queue', 'owner', 'creator', 'subject', 'status', 'priority',
     'initial_priority', 'final_priority', 'requestors', 'cc', 'admin_cc',
     'created', 'starts', 'started', 'due', 'resolved', 'told',
-    'time_estimated', 'time_worked', 'time_left', 'last_updated',
+    'time_estimated', 'time_worked', 'time_left', 'last_updated', 'sla',
 );
 
 BEGIN {

--- a/t/25-queue.t
+++ b/t/25-queue.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 16;
+use Test::More tests => 17;
 use Test::Exception;
 
 use constant METHODS => (
@@ -12,7 +12,7 @@ use constant METHODS => (
 
     # attrubutes:
     'id', 'name', 'description', 'correspond_address', 'comment_address',
-    'initial_priority', 'final_priority', 'default_due_in',
+    'initial_priority', 'final_priority', 'default_due_in', 'sla_disabled',
 );
 
 BEGIN {


### PR DESCRIPTION
The `SLA` and `SLADisabled` attributes were added to `Ticket` and `Queue` objects, respectievly, in RT 4.4.3. This PR adds support for those attributes.