### PR TITLE
Fixes 'uninitialized value' message when calling get_attachments_meta…

### DIFF
--- a/lib/RT/Client/REST.pm
+++ b/lib/RT/Client/REST.pm
@@ -174,7 +174,7 @@ sub get_attachments_metadata {
     return map {
       # Matches: '50008989: (Unnamed) (text/plain / 1.9k),'
       my @c = $_ =~ m/^\s*(\d+):\s+(.+)\s+\(([^\s]+)\s+\/\s+([^\s]+)\)\s*,\s*$/;
-      { id => $c[0], Filename => $c[1] eq '(Unnamed)' ? undef : $c[1], Type => $c[2], Size => $c[3] };
+      { id => $c[0], Filename => ( defined($c[1]) && ( $c[1] eq '(Unnamed)' ) ) ? undef : $c[1], Type => $c[2], Size => $c[3] };
     } split(/\n/, $k->{Attachments});
 }
 


### PR DESCRIPTION
…data.

I was getting "Use of uninitialized value $c[1] in string eq at
/usr/share/perl5/RT/Client/REST.pm line 177." when calling
get_attachments_metadata.  This commit checks for the value to be
defined first, thus preventing the unwanted message.

This change fixes issue 22 for me, and I've been running it in a production environment for a long time now.