### PR TITLE
Fix get_attachments_metadata missing the last attachment's data when …

### DIFF
--- a/lib/RT/Client/REST.pm
+++ b/lib/RT/Client/REST.pm
@@ -173,7 +173,7 @@ sub get_attachments_metadata {
     }
     return map {
       # Matches: '50008989: (Unnamed) (text/plain / 1.9k),'
-      my @c = $_ =~ m/^\s*(\d+):\s+(.+)\s+\(([^\s]+)\s+\/\s+([^\s]+)\)\s*,\s*$/;
+      my @c = $_ =~ m/^\s*(\d+):\s+(.+)\s+\(([^\s]+)\s+\/\s+([^\s]+)\)\s*,?\s*$/;
       { id => $c[0], Filename => $c[1] eq '(Unnamed)' ? undef : $c[1], Type => $c[2], Size => $c[3] };
     } split(/\n/, $k->{Attachments});
 }


### PR DESCRIPTION
…many exist.

When calling get_attachments_metadata, data from the last attachment was
being missed due to a parsing problem.

This fixes issue #23.  I have been running with this fix in a production environment for a long time.